### PR TITLE
removed CSRF bypass because no allowlist header present

### DIFF
--- a/conf/application.conf
+++ b/conf/application.conf
@@ -19,10 +19,6 @@ application.router = prod.Routes
 
 play.filters.headers.contentSecurityPolicy = "default-src 'self' 'unsafe-inline' localhost:7788 localhost:9032 localhost:9250 www.google-analytics.com fonts.gstatic.com ssl.gstatic.com data: www.googletagmanager.com www.gstatic.com fonts.googleapis.com tagmanager.google.com"
 
-play.filters.csrf.header.bypassHeaders {
-  Csrf-Token = "nocheck"
-}
-
 # An ApplicationLoader that uses Guice to bootstrap the application.
 play.application.loader = "uk.gov.hmrc.play.bootstrap.ApplicationLoader"
 


### PR DESCRIPTION
The CSRF bypass header is being used without an allowlist. Have removed it in this commit to close this vulnerability.
https://jira.tools.tax.service.gov.uk/browse/PSEC-1051